### PR TITLE
Let sandpaper translate section headings

### DIFF
--- a/episodes/compare-interventions.Rmd
+++ b/episodes/compare-interventions.Rmd
@@ -96,7 +96,6 @@ output_baseline <- model_default(
 
 ::::::::::::::::::::::::::::::::::::: prereq
 
-## Prerequisites
 + Complete tutorials [Simulating transmission](../episodes/simulating-transmission.md) and [Modelling interventions](../episodes/modelling-interventions.md)
 
 Learners should familiarise themselves with following concept dependencies before working through this tutorial: 
@@ -338,8 +337,6 @@ output <- model_vacamole(
 
 
 ::::::::::::::::: solution
-
-### SOLUTION
 
 1.  Run the model
 

--- a/episodes/model-choices.Rmd
+++ b/episodes/model-choices.Rmd
@@ -26,7 +26,6 @@ library(ggplot2)
 
 ::::::::::::::::::::::::::::::::::::: prereq
 
-## Prerequisites
 + Complete tutorial [Simulating transmission](../episodes/simulating-transmission.md)
 :::::::::::::::::::::::::::::::::
 
@@ -121,8 +120,6 @@ Which of the following models would be an appropriate choice for this task:
 
 ::::::::::::::::: hint
 
-### HINT
-
 Consider the following questions:
 
 ::::::::::::::::::::::::::::::::::::: checklist
@@ -139,9 +136,6 @@ Consider the following questions:
 
 
 ::::::::::::::::: solution
-
-### SOLUTION
-
 
 + What is the infection/disease of interest? **Ebola**
 + Do we need a deterministic or stochastic model?  **A stochastic model would allow us to explore variation in the early stages of the outbreak**
@@ -330,8 +324,6 @@ Adapt the code from the [accounting for uncertainty](../episodes/simulating-tran
 ::::::::::::::::::::::
 
 ::::::::::::::::: solution
-
-### SOLUTION
 
 1. Run the model once and plot the number of infectious individuals  through time
 

--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -14,7 +14,6 @@ library(epidemics)
 
 - How do I investigate the effect of interventions on disease trajectories? 
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: objectives
@@ -25,7 +24,6 @@ library(epidemics)
 
 ::::::::::::::::::::::::::::::::::::: prereq
 
-## Prerequisites
 + Complete tutorial on [Simulating transmission](../episodes/simulating-transmission.md).
 
 Learners should also familiarise themselves with following concept dependencies before working through this tutorial: 
@@ -406,8 +404,6 @@ Plot the three interventions vaccination, school closure and mask mandate and th
 
 
 :::::::::::::::::::::::: solution 
-
-## Output
 
 ```{r plot_vaccinate, echo = TRUE, message = FALSE, fig.width = 10}
 # create intervention_type column for plotting

--- a/episodes/simulating-transmission.Rmd
+++ b/episodes/simulating-transmission.Rmd
@@ -34,8 +34,6 @@ webshot::install_phantomjs(force = TRUE)
 
 ::::::::::::::::::::::::::::::::::::: prereq
 
-## Prerequisites
-
 Learners should familiarise themselves with following concept dependencies before working through this tutorial: 
 
 **Mathematical Modelling** : [Introduction to infectious disease models](https://doi.org/10.1038/s41592-020-0856-2), [state variables](../learners/reference.md#state), [model parameters](../learners/reference.md#parsode), [initial conditions](../learners/reference.md#initial), [differential equations](../learners/reference.md#ordinary).
@@ -275,8 +273,6 @@ contact_matrix
 ```
 
 :::::::::::::::::::::::: solution 
-
-## Output
  
 ```{r polymod_uk, echo = FALSE, message = FALSE}
 polymod <- socialmixr::polymod

--- a/episodes/template.Rmd
+++ b/episodes/template.Rmd
@@ -19,8 +19,6 @@ exercises: 5 # exercise time in minutes
 
 ::::::::::::::::::::::::::::::::::::: prereq
 
-## Prerequisites
-
 List (and hyperlink) the lessons/packages which need to be covered before this lesson
 
 :::::::::::::::::::::::::::::::::


### PR DESCRIPTION
With this change, sandpaper can now only do its magic and translate the strings instead of relying on hardcoded section title added in the lesson source

![image](https://github.com/epiverse-trace/tutorials-late/assets/10783929/f244a318-c503-4236-b7bf-7b6b1724a3b4)

I'll let you do the change in the other repos.