### PR TITLE
Use Ubuntu 22.04 for lint GHA workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,9 @@ name: lint
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    # we get errors about pak not supporting 24.04 for sysdeps with ubuntu-latest
+    # https://github.com/r-lib/pak/blob/683f1be2cc2662d8e4073167910a1dd2f1e63b89/R/system-requirements.R#L194-L204
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/.local/share/renv/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RENV_PATHS_ROOT: ~/.local/share/renv/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Should fix the check failures we're seeing
