### PR TITLE
Fix glossary (`learners/reference.md`) entry

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -95,16 +95,17 @@ This can be different to the [incubation period](#incubation) as shown in Figure
 
 
 ## N
+
 [Non-pharmaceutical interventions]{#NPIs}
 : Non-pharmaceutical interventions (NPIs) are measures put in place to reduce transmission that do not include the administration of drugs or vaccinations. [More information on NPIs](https://www.gov.uk/government/publications/technical-report-on-the-covid-19-pandemic-in-the-uk/chapter-8-non-pharmaceutical-interventions).
 
-## O
-[Ordinary differential equations]{#ordinary}
-: Ordinary differential equations (ODEs) can be used to represent the rate of change of one variable (e.g. number of infected individuals) with respect to another (e.g. time). Check out this introduction to [ODEs](https://mathinsight.org/ordinary_differential_equation_introduction). ODEs are widely used in infectious disease modelling to model the flow of individuals between different disease states. 
 [Natural history of disease]{#naturalhistory} 
 : Refers to the development of disease from beginning to end without any treatment or intervention. In fact, given the harmfulness of an epidemic, treatment or intervention measures are inevitable. Therefore, it is difficult for the natural history of a disease to be unaffected by the various coupling factors. ([Xiang et al, 2021](https://www.sciencedirect.com/science/article/pii/S2468042721000038))
 
 ## O
+
+[Ordinary differential equations]{#ordinary}
+: Ordinary differential equations (ODEs) can be used to represent the rate of change of one variable (e.g. number of infected individuals) with respect to another (e.g. time). Check out this introduction to [ODEs](https://mathinsight.org/ordinary_differential_equation_introduction). ODEs are widely used in infectious disease modelling to model the flow of individuals between different disease states. 
 
 [Offspring distribution]{#offspringdist}
 : Distribution of the number of secondary cases caused by a particular infected individual. ([Lloyd-Smith et al., 2005](https://www.nature.com/articles/nature04153), [Endo et al., 2020](https://wellcomeopenresearch.org/articles/5-67/v3))


### PR DESCRIPTION
This PR addresses #148 by removing the duplicated "O" section and moving "Natural history of disease" under the correct heading in the glossary (`learners/reference.md`).

* **Please check if the PR fulfills these requirements**

- [X] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix glossary entries.

* **What is the current behavior?** (You can also link to an open issue here)

N/A

* **What is the new behavior (if this is a feature change)?**

No behaviour change.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
