### PR TITLE
use plain mermaid fences instead of knitr engine chunks

### DIFF
--- a/episodes/compare-interventions.Rmd
+++ b/episodes/compare-interventions.Rmd
@@ -256,8 +256,7 @@ The Vacamole model is a deterministic model based on a system of Ordinary Differ
 
 The diagram below describes the flow of individuals through the different compartments.
 
-```{mermaid}
-# nolint start
+```mermaid
 flowchart LR
     Ev["E<sub>V</sub>"]:::vaccinated
     Iv["I<sub>V</sub>"]:::vaccinated
@@ -284,7 +283,6 @@ flowchart LR
     H -->|"recovery (&gamma;)"| R
 
     classDef vaccinated fill:#808080,color:#fff
-# nolint end
 ```
 
 

--- a/episodes/compare-interventions.Rmd
+++ b/episodes/compare-interventions.Rmd
@@ -258,6 +258,8 @@ The diagram below describes the flow of individuals through the different compar
 
 ```mermaid
 flowchart LR
+    accTitle: Vacamole compartmental model with two-dose vaccination
+    accDescr: Eleven compartments: S (Susceptible), E and E_V (Exposed unvaccinated and vaccinated), I and I_V (Infectious unvaccinated and vaccinated), H and H_V (Hospitalised unvaccinated and vaccinated), D (Dead), R (Recovered), V1 (first vaccine dose), V2 (second vaccine dose). Transitions: S to E by infection at rate beta; S to V1 by first-dose vaccination at rate nu1; V1 to E by infection at rate beta; V1 to V2 by second-dose vaccination at rate nu2; V2 to E_V by infection at rate beta; E and E_V to I and I_V by onset of infectiousness at rate alpha; I and I_V to H and H_V by hospitalisation at rates eta and eta_V; I, I_V, H, H_V to D by death at rates omega and omega_V; I, I_V, H, H_V to R by recovery at rate gamma.
     Ev["E<sub>V</sub>"]:::vaccinated
     Iv["I<sub>V</sub>"]:::vaccinated
     Hv["H<sub>V</sub>"]:::vaccinated

--- a/episodes/contact-matrices.Rmd
+++ b/episodes/contact-matrices.Rmd
@@ -244,12 +244,10 @@ Whereas a contact matrix gives the average number of contacts that one groups ma
 
 Consider the SIR model where individuals are categorized as either susceptible $S$,  infected $I$ and recovered $R$. The schematic below shows the processes which describe the flow of individuals between the disease states $S$, $I$ and $R$ and the key parameters for each process.
 
-```{mermaid}
-# nolint start
+```mermaid
 flowchart LR
     S -->|"infection<br>(transmission rate &beta;)"| I
     I -->|"recovery<br>(recovery rate &gamma;)"| R
-# nolint end
 ```
 
 The [differential equations](../learners/reference.md#ordinary) below describe how individuals move from one state to another [(Bjørnstad et al. 2020)](https://doi.org/10.1038/s41592-020-0822-z).

--- a/episodes/contact-matrices.Rmd
+++ b/episodes/contact-matrices.Rmd
@@ -246,6 +246,8 @@ Consider the SIR model where individuals are categorized as either susceptible $
 
 ```mermaid
 flowchart LR
+    accTitle: SIR compartmental model
+    accDescr: Three compartments: S (Susceptible), I (Infectious), R (Recovered). Transitions: S to I by infection at transmission rate beta; I to R by recovery at rate gamma.
     S -->|"infection<br>(transmission rate &beta;)"| I
     I -->|"recovery<br>(recovery rate &gamma;)"| R
 ```

--- a/episodes/model-choices.Rmd
+++ b/episodes/model-choices.Rmd
@@ -161,13 +161,11 @@ Consider the following questions:
 
 A deterministic SEIR model with age specific direct transmission. 
 
-```{mermaid}
-# nolint start
+```mermaid
 flowchart LR
     S -->|"infection<br>(transmissibility &beta;)"| E
     E -->|"onset of infectiousness<br>(infectiousness rate &alpha;)"| I
     I -->|"recovery<br>(recovery rate &gamma;)"| R
-# nolint end
 ```
 
 
@@ -187,8 +185,7 @@ The key parameters affecting the transition between states are:
 
 **Note:** the functional relationship between the preinfectious  period ($\rho^E$) and the transition rate between exposed and infectious ($\gamma^E$) is $\rho^E = k^E/\gamma^E$ where $k^E$ is the shape of the Erlang distribution. Similarly for the infectious period $\rho^I = k^I/\gamma^I$. For more detail on the stochastic model formulation refer to the section on [Discrete-time Ebola virus disease model](https://epiverse-trace.github.io/epidemics/articles/model_ebola.html#details-discrete-time-ebola-virus-disease-model) in the "Modelling responses to a stochastic Ebola virus epidemic" vignette. 
 
-```{mermaid}
-# nolint start
+```mermaid
 flowchart LR
     S -->|"infection (&beta;)"| E
     E -->|"onset of infectiousness (&gamma; E)"| I
@@ -196,7 +193,6 @@ flowchart LR
     F -->|"safe burial (one timestep)"| R
     I -->|"hospitalisation (p hosp)"| H
     H -->|"recovery or safe burial (&gamma; I)"| R
-# nolint end
 ```
 
 The model has additional parameters describing the transmission risk in hospital and funeral settings: 

--- a/episodes/model-choices.Rmd
+++ b/episodes/model-choices.Rmd
@@ -163,6 +163,8 @@ A deterministic SEIR model with age specific direct transmission.
 
 ```mermaid
 flowchart LR
+    accTitle: SEIR compartmental model
+    accDescr: Four compartments: S (Susceptible), E (Exposed), I (Infectious), R (Recovered). Transitions: S to E by infection at transmissibility beta; E to I by onset of infectiousness at rate alpha; I to R by recovery at rate gamma.
     S -->|"infection<br>(transmissibility &beta;)"| E
     E -->|"onset of infectiousness<br>(infectiousness rate &alpha;)"| I
     I -->|"recovery<br>(recovery rate &gamma;)"| R
@@ -187,6 +189,8 @@ The key parameters affecting the transition between states are:
 
 ```mermaid
 flowchart LR
+    accTitle: SEIHFR compartmental model for Ebola virus disease
+    accDescr: Six compartments: S (Susceptible), E (Exposed), I (Infectious), H (Hospitalised), F (Funeral), R (Removed). Transitions: S to E by infection at rate beta; E to I by onset of infectiousness at rate gamma_E; I to F by death leading to funeral at rate gamma_I; F to R by safe burial in one timestep; I to H by hospitalisation at probability p_hosp; H to R by recovery or safe burial at rate gamma_I.
     S -->|"infection (&beta;)"| E
     E -->|"onset of infectiousness (&gamma; E)"| I
     I -->|"death funeral (&gamma; I)"| F

--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -385,6 +385,8 @@ The diagram below shows the SEIRV model implemented using `model_default()` wher
 
 ```mermaid
 flowchart LR
+    accTitle: SEIRV compartmental model with vaccination
+    accDescr: Five compartments: S (Susceptible), E (Exposed), I (Infectious), R (Recovered), V (Vaccinated). Transitions: S to E by infection at rate beta; S to V by vaccination at rate nu; E to I by onset of infectiousness at rate alpha; I to R by recovery at rate gamma.
     S -->|"infection (&beta;)"| E
     S -->|"vaccination (&nu;)"| V
     E -->|"onset of infectiousness (&alpha;)"| I

--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -383,14 +383,12 @@ Pharmaceutical interventions (PIs) are measures such as vaccination and mass tre
 
 The diagram below shows the SEIRV model implemented using `model_default()` where susceptible individuals are vaccinated and then move to the $V$ class.
 
-```{mermaid}
-# nolint start
+```mermaid
 flowchart LR
     S -->|"infection (&beta;)"| E
     S -->|"vaccination (&nu;)"| V
     E -->|"onset of infectiousness (&alpha;)"| I
     I -->|"recovery (&gamma;)"| R
-# nolint end
 ```
 
 

--- a/episodes/simulating-transmission.Rmd
+++ b/episodes/simulating-transmission.Rmd
@@ -89,13 +89,11 @@ In this tutorial, we will use the default model in `{epidemics}`, called `model_
 The schematic below shows the processes which describe the flow of individuals between the disease states $S$, $E$, $I$ and $R$ and the key parameters for each process.
 
 
-```{mermaid}
-# nolint start
+```mermaid
 flowchart LR
     S -->|"infection<br>(transmission rate &beta;)"| E
     E -->|"onset of infectiousness<br>(infectiousness rate &alpha;)"| I
     I -->|"recovery<br>(recovery rate &gamma;)"| R
-# nolint end
 ```
 
 

--- a/episodes/simulating-transmission.Rmd
+++ b/episodes/simulating-transmission.Rmd
@@ -91,6 +91,8 @@ The schematic below shows the processes which describe the flow of individuals b
 
 ```mermaid
 flowchart LR
+    accTitle: SEIR compartmental model
+    accDescr: Four compartments: S (Susceptible), E (Exposed), I (Infectious), R (Recovered). Transitions: S to E by infection at transmission rate beta; E to I by onset of infectiousness at rate alpha; I to R by recovery at rate gamma.
     S -->|"infection<br>(transmission rate &beta;)"| E
     E -->|"onset of infectiousness<br>(infectiousness rate &alpha;)"| I
     I -->|"recovery<br>(recovery rate &gamma;)"| R


### PR DESCRIPTION
## Summary

- Replaces ` ```{mermaid} ` (knitr engine syntax) with plain ` ```mermaid ` fences across all 6 diagrams in 5 episodes
- Plain fences render correctly in the Carpentries Workbench and are not processed by knitr, so lintr never inspects the flowchart content
- Removes `# nolint start/end` markers that were previously needed to silence lintr parse errors on mermaid syntax

Closes part of #46.

## Test plan

- [x] Confirm all 6 mermaid diagrams render in the built lesson (`sandpaper::build_lesson()`)
- [x] Confirm `lintr::lint_dir("episodes")` reports no errors or warnings related to the mermaid chunks
- [x] Check the Vacamole diagram in `compare-interventions` still shows gray fill on vaccinated compartments

🤖 Generated with [Claude Code](https://claude.com/claude-code)