### PR TITLE
drop varnish at epiversetheme branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,4 +80,4 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
-varnish: epiverse-trace/varnish@epiversetheme
+varnish: epiverse-trace/varnish


### PR DESCRIPTION
plan: https://github.com/epiverse-trace/varnish/issues/16

assessment: after merging #111 , build workflow failed. 

decision: something similar happened locally, we assume that varnish needs the latest version