### PR TITLE
Update tutorials-late episodes for {epidemics} v0.5.0

### DIFF
--- a/episodes/compare-interventions.Rmd
+++ b/episodes/compare-interventions.Rmd
@@ -36,7 +36,7 @@ contacts_byage <- socialmixr::contact_matrix(
 )
 
 # prepare contact matrix
-contacts_byage_matrix <- t(contacts_byage$matrix)
+contacts_byage_matrix <- contacts_byage$matrix
 
 # prepare the demography vector
 demography_vector <- contacts_byage$demography$population
@@ -368,7 +368,7 @@ contacts_byage_uk <- socialmixr::contact_matrix(
   survey_pop = uk_pop
 )
 # prepare contact matrix
-contacts_byage_matrix_uk <- t(contacts_byage_uk$matrix)
+contacts_byage_matrix_uk <- contacts_byage_uk$matrix
 
 # extract demography vector
 demography_vector <- contacts_byage_uk$demography$population

--- a/episodes/contact-matrices.Rmd
+++ b/episodes/contact-matrices.Rmd
@@ -342,13 +342,15 @@ Recall from **A Note on Notation** above that entry $C[i,j]$ of the matrix from 
 
 To convert this into a contact *rate*, we read the matrix the other way round: "susceptibles in group $i$ ($S_i$), *contacted by* group $j$". That's the same contact seen from the susceptible side rather than the reporting side — group $j$ is doing the contacting, group $i$ is being exposed. In other words, the entry we need at position $(i,j)$ is the reported contact at `socialmixr`'s position $(j,i)$: the two conventions are transposes of each other.
 
-To go from one convention to the other, we transpose the matrix:
+Going from one convention to the other means transposing the matrix. Some packages expect you to do this yourself; `{epidemics}` does it for you.
+
+From version 0.5.0, the `{epidemics}` model functions transpose the contact matrix internally, so a matrix from `socialmixr::contact_matrix()` should be passed to `epidemics::population()` exactly as it is returned, with no call to `t()`:
 
 ```r
-contacts_byage_matrix <- t(contacts_byage$matrix)
+contacts_byage_matrix <- contacts_byage$matrix
 ```
 
-This is the matrix used as $C_{i,j}$ in $\beta S_i \sum_j C_{i,j} I_j/N_j$ below.
+Internally, it is the transposed matrix that is used as $C_{i,j}$ in $\beta S_i \sum_j C_{i,j} I_j/N_j$ below.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/disease-burden.Rmd
+++ b/episodes/disease-burden.Rmd
@@ -108,7 +108,7 @@ contacts_byage <- socialmixr::contact_matrix(
 )
 
 # prepare contact matrix
-contacts_byage_matrix <- t(contacts_byage$matrix)
+contacts_byage_matrix <- contacts_byage$matrix
 
 # prepare the demography vector
 demography_vector <- contacts_byage$demography$population

--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -29,7 +29,7 @@ Learners should also familiarise themselves with the following concept dependenc
 
 **Outbreak response**: [Intervention types](https://www.cdc.gov/nonpharmaceutical-interventions/).
 
-**R packages installed**: `{epidemics}`, `{contactsurveys}`, `{socialmixr}`, `{scales}`, `{tidyverse}`.
+**R packages installed**: `{epidemics}`, `{contactsurveys}`, `{socialmixr}`, `{wpp2024}`, `{scales}`, `{tidyverse}`.
 
 :::::::::::::::::::::::::::::::::
 
@@ -39,7 +39,7 @@ Install packages if they are not already installed
 
 ```r
 if (!base::require("pak")) install.packages("pak")
-pak::pak(c("epiverse-trace/epidemics", "contactsurveys", "socialmixr", "scales", "tidyverse"))
+pak::pak(c("epiverse-trace/epidemics", "PPgp/wpp2024", "contactsurveys", "socialmixr", "scales", "tidyverse"))
 ```
 
 If you have any error message,
@@ -110,8 +110,8 @@ contacts_byage <- socialmixr::contact_matrix(
   survey_pop = uk_pop
 )
 
-# transpose contact matrix
-contacts_byage_matrix <- t(contacts_byage$matrix)
+# prepare contact matrix
+contacts_byage_matrix <- contacts_byage$matrix
 
 # prepare the demography vector
 demography_vector <- contacts_byage$demography$population

--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -84,7 +84,7 @@ Then start with the livecoding directly with interventions.
 
 We will investigate the effect of interventions on a COVID-19 outbreak using an SEIR model (`model_default()` in the R package `{epidemics}`). To be able to see the effect of our intervention, we will run a baseline variant of the model, i.e,  without intervention.
 
-The SEIR model divides the population into four compartments: Susceptible (S), Exposed (E), Infectious (I), and Recovered (R). We will set the following parameters for our model: $R_0 = 2.7$ (basic reproduction number), latent period or pre-infectious period $= 4$ days, and the infectious period $= 5.5$ days (parameters adapted from [Davies et al. (2020)](https://doi.org/10.1016/S2468-2667(20)30133-X)). We adopt a contact matrix with age bins 0-18, 18-65, 65 years and older using `{socialmixr}`, and assume that one in every 1 million individuals in each age group is infectious at the start of the epidemic.
+The SEIR model divides the population into four compartments: Susceptible (S), Exposed (E), Infectious (I), and Recovered (R). We will set the following parameters for our model: $R_0 = 2.7$ (basic reproduction number), latent period or pre-infectious period $= 4$ days, and the infectious period $= 5.5$ days (parameters adapted from [Davies et al. (2020)](https://doi.org/10.1016/S2468-2667(20)30133-X)). We adopt a contact matrix with age bins 0-15, 15-65, 65 years and older using `{socialmixr}`, and assume that one in every 1 million individuals in each age group is infectious at the start of the epidemic.
 
 ```{r model_setup, echo = TRUE, message = FALSE, warning = FALSE}
 # download and load survey data

--- a/episodes/simulating-transmission.Rmd
+++ b/episodes/simulating-transmission.Rmd
@@ -31,7 +31,7 @@ Learners should familiarise themselves with the following concept dependencies b
 
 **Epidemic theory**: [Transmission](https://doi.org/10.1155/2011/267049), [Reproduction number](https://doi.org/10.3201/eid2501.171901).
 
-**R packages installed**: `{epidemics}`, `{contactsurveys}`, `{socialmixr}`, `{scales}`, `{tidyverse}`.
+**R packages installed**: `{epidemics}`, `{contactsurveys}`, `{socialmixr}`, `{wpp2024}`, `{scales}`, `{tidyverse}`.
 
 :::::::::::::::::::::::::::::::::
 
@@ -41,7 +41,7 @@ Install these packages if they are not already installed
 
 ```r
 if (!base::require("pak")) install.packages("pak")
-pak::pak(c("epiverse-trace/epidemics", "contactsurveys", "socialmixr", "scales", "tidyverse"))
+pak::pak(c("epiverse-trace/epidemics", "PPgp/wpp2024", "contactsurveys", "socialmixr", "scales", "tidyverse"))
 ```
 
 If you have any error message,
@@ -195,7 +195,7 @@ contacts_byage <- socialmixr::contact_matrix(
 )
 
 # prepare contact matrix
-contacts_byage_matrix <- t(contacts_byage$matrix)
+contacts_byage_matrix <- contacts_byage$matrix
 
 # print
 contacts_byage_matrix

--- a/episodes/vaccine-comparisons.Rmd
+++ b/episodes/vaccine-comparisons.Rmd
@@ -92,7 +92,7 @@ contacts_byage <- socialmixr::contact_matrix(
 
 
 # prepare contact matrix
-contacts_byage_matrix <- t(contacts_byage$matrix)
+contacts_byage_matrix <- contacts_byage$matrix
 
 # prepare the demography vector
 demography_vector <- contacts_byage$demography$population

--- a/learners/contact-normalization.Rmd
+++ b/learners/contact-normalization.Rmd
@@ -81,7 +81,7 @@ Rather than just using the raw number of contacts, we can instead normalise the 
 In the case of the above model, we want to define $\beta  C_{i,j}$ so that the model has a specified valued of $R_0$. If the entry of the contact matrix $C[i,j]$ represents the contacts of population $i$ with $j$, it is equivalent to `contacts_byage$matrix[i,j]`, and the maximum eigenvalue of this matrix represents the typical magnitude of contacts, not the typical magnitude of transmission. We must therefore normalise the matrix $C$ so the maximum eigenvalue is one; we call this matrix $C_{normalised}$. Because the rate of recovery is $\gamma$, individuals will be infectious on average for $1/\gamma$ days. So $\beta$ as a model input is calculated from $R_0$, the scaling factor and the value of $\gamma$  (i.e. mathematically we use the fact that the dominant eigenvalue of the matrix $R_0 \times C_{normalised}$ is equal to $\beta / \gamma$).
 
 ```{r}
-contacts_byage_matrix <- t(contacts_byage$matrix)
+contacts_byage_matrix <- contacts_byage$matrix
 scaling_factor <- 1 / max(eigen(contacts_byage_matrix)$values)
 normalised_matrix <- contacts_byage_matrix * scaling_factor
 ```

--- a/learners/files/baseline-interventions-en.R
+++ b/learners/files/baseline-interventions-en.R
@@ -29,8 +29,8 @@ cm_results <- socialmixr::contact_matrix(
   survey_pop = uk_pop
 )
 
-# transpose contact matrix
-cm_matrix <- t(cm_results$matrix)
+# prepare contact matrix
+cm_matrix <- cm_results$matrix
 
 # prepare the demography vector
 demography_vector <- cm_results$demography$population

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -70,7 +70,7 @@ To install R and RStudio, follow these instructions <https://posit.co/download/r
 
 Hold on: This is a great time to make sure your R installation is current.
 
-This tutorial requires **R version 4.0.0 or later**. 
+This tutorial requires **R version 4.1.0 or later**. 
 
 :::::::::::::::::::::::::::::
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [X] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- ~[ ] Tests for the changes have been added (for bug fixes / features)~ _Not applicable_
- [X] Docs have been added / updated (for bug fixes / features)
- [X] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR updates the `episodes/` in tutorials-late to use the latest version of {epidemics} (v0.5.0). 

* **What is the current behavior?** (You can also link to an open issue here)

The current behaviour was using the previous release of {epidemics} (v0.4.0).

* **What is the new behavior (if this is a feature change)?**

The `episodes/` are updated to use the new {epidemics} functions correctly, e.g. not transposing the contact matrix before running `epidemics::model_*()` as this is now handled internally in {epidemic} v0.5.0.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This has breaking changes to the tutorials scripts, but this is required to keep up-to-date with the latest version of the {epidemics} Epivers-TRACE package.

* **Other information**:

None.