### PR TITLE
Add callout defining vaccination rate before vaccination() model call

### DIFF
--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -440,11 +440,13 @@ $$
 \nu_{g_i} = \frac{\text{daily doses in group } g_i}{\text{population in group } g_i}
 $$
 
-For example, in February 2021, 425,000 daily doses were administered to the population aged 65+, with a population size of 12,730,000:
+For example, during the NHS England autumn 2023 COVID-19 booster campaign, an average of 98,000 daily doses were administered to the population aged 65+, with a population size of 12,730,000:
 
 $$
-\nu_{65+} = \frac{425{,}000}{12{,}730{,}000} = 0.0334
+\nu_{65+} = \frac{98{,}000}{12{,}730{,}000} = 0.0077
 $$
+
+61.5% of people aged 65+ had received an autumn COVID-19 booster by 30 November 2023, since the campaign began on 11 September 2023 (80 days). 61.5% × 12,730,000 ≈ 7,829,000 doses ÷ 80 days ≈ 98,000 doses/day. ([NHS England, Vaccinations: COVID-19](https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-vaccinations/))
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/modelling-interventions.Rmd
+++ b/episodes/modelling-interventions.Rmd
@@ -431,6 +431,23 @@ vaccinate <- epidemics::vaccination(
 )
 ```
 
+::::::::::::::::::::::::::::::::::::: callout
+### Vaccination rate
+
+The vaccination rate $\nu_{g_i}$ is the number of doses given daily to age group $g_i$ among the total population in that age group:
+
+$$
+\nu_{g_i} = \frac{\text{daily doses in group } g_i}{\text{population in group } g_i}
+$$
+
+For example, in February 2021, 425,000 daily doses were administered to the population aged 65+, with a population size of 12,730,000:
+
+$$
+\nu_{65+} = \frac{425{,}000}{12{,}730{,}000} = 0.0334
+$$
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
 We pass our vaccination object into the model using the argument `vaccination = vaccinate`:
 
 ```{r output_vaccinate}


### PR DESCRIPTION
Learners see `nu` used in epidemics::vaccination() without a definition; this adds the formula and a worked example (age 65+, Feb 2023, UK) just before the object is passed into model_default().

* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [ ] ~A new item has been added to `NEWS.md`~
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  - add an example to get the vaccination rate

* **What is the current behavior?** (You can also link to an open issue here)

  - direct usage of 0.01 as vaccination rate

* **What is the new behavior (if this is a feature change)?**

  - add a calloutbox to explain, as also intended by the box on "effect of interventions on contacts"

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  - No

* **Other information**:
